### PR TITLE
adding episode duration

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,7 @@ export namespace ApiResponse {
     feedImage: string;
     feedId: number;
     feedLanguage: string;
+    durartion: number;
   }
 
   export interface Search {


### PR DESCRIPTION
Recently the duration was added to the episode response. In this PR I'm adding the type definition for the duration.

See example response:
```
{
  "id": 310830806,
  "guid": "https://luftpost-podcast.de/?p=1175",
  "link": "https://luftpost-podcast.de/senegal/",
  "image": "",
  "title": "Senegal",
  "feedId": 1055299,
  "season": 0,
  "episode": null,
  "duration": 3788,
  "explicit": 0,
  "feedImage": "https://luftpost-podcast.de/cover.png",
  "chaptersUrl": null,
  "dateCrawled": 1599986903,
  "description": "Über Afrika ist auf meiner Landkarte immer noch etwas unterrepräsentiert, deshalb freut es mich um so mehr, dass ich mit Jessi über ihre Reise in den Senegal sprechen durfte. Sie war dort für drei Wochen mit ihrem Mann um dort in der Hauptstadt Dakar zum ersten Mal ihre Schwiegerfamilie zu treffen. Sie erzählt von der Gastfreundschaft und [&#8230;]",
  "episodeType": null,
  "enclosureUrl": "https://luftpost-podcast.de/media/luftpost107-senegal.mp3",
  "feedItunesId": 409553739,
  "feedLanguage": "de-DE",
  "datePublished": 1598647106,
  "enclosureType": "audio/mpeg",
  "transcriptUrl": null,
  "enclosureLength": 53179769,
  "datePublishedPretty": "August 28, 2020 3:38pm"
}
```